### PR TITLE
Queue locking for concurrency = 1

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -13,6 +13,7 @@
 var EventEmitter = require('events').EventEmitter
   , redis        = require('../redis')
   , events       = require('./events')
+  , Warlock      = require('node-redis-warlock')
   , Job          = require('./job')
   , noop         = function() {
 };
@@ -44,6 +45,8 @@ function Worker( queue, type ) {
   this.client  = Worker.client || (Worker.client = redis.createClient());
   this.running = true;
   this.job     = null;
+  this.lockClient = redis.createClient();
+  this.warlock    = new Warlock(this.lockClient);
 }
 
 /**
@@ -62,6 +65,7 @@ Worker.prototype.__proto__ = EventEmitter.prototype;
 
 Worker.prototype.start = function( fn ) {
   var self = this;
+  var key = 'queue-lock';
   self.idle();
   if( !self.running ) return;
   this.queue.removeAllListeners('job ttl exceeded');
@@ -79,13 +83,26 @@ Worker.prototype.start = function( fn ) {
     }
   }.bind( this ));
 
-  self.getJob(function( err, job ) {
-    if( err ) self.error(err, job);
-    if( !job || err ) return process.nextTick(function() {
-      self.start(fn);
-    });
-    self.process(job, fn);
+  self.warlock.lock(key, 10000, function (err, unlock) {
+    if (err) {
+      self.error(err);
+    }
+
+    if (typeof unlock === 'function') {
+      self.getJob(function( err, job ) {
+        if( err ) self.error(err, job);
+        if( !job || err ) return process.nextTick(function() {
+          self.start(fn);
+        });
+        self.process(job, fn, unlock);
+      });
+    } else {
+      process.nextTick(function() {
+        self.start(fn);
+      });
+    }
   });
+
   return this;
 };
 
@@ -142,7 +159,7 @@ Worker.prototype.failed = function( job, theErr, fn ) {
  * @api public
  */
 
-Worker.prototype.process = function( job, fn ) {
+Worker.prototype.process = function( job, fn, unlock ) {
   var self  = this
     , start = new Date();
 
@@ -155,6 +172,7 @@ Worker.prototype.process = function( job, fn ) {
    */
   var createDoneCallback = function( jobId ) {
     return function( err, result ) {
+      unlock();
       if( self.drop_user_callbacks ) {
         //console.warn( 'Worker started to shutdown, ignoring execution of done callback' );
         //job.log( 'Worker started to shutdown, ignoring execution of done callback' );

--- a/test/redis_lock.js
+++ b/test/redis_lock.js
@@ -1,0 +1,74 @@
+(function () {
+  var kue = require('../'),
+      async = require('async'),
+      cluster = require('cluster'),
+      queue = kue.createQueue(),
+      redis = require('redis'),
+      client = redis.createClient(),
+      clusterSize = process.env.SIZE || 2, // require('os').cpus().length;
+      jobType = 'race';
+
+  if (cluster.isMaster) {
+    cleanup(function(){
+      for (var n = 0; n < 10; n++) {
+        queue.create(jobType, {
+          n: n
+        }).save();
+      }
+
+      cluster.on('exit', function (worker) {
+        for (var id in cluster.workers) {
+          // have to use .process.kill here
+          // https://github.com/nodejs/node-v0.x-archive/issues/5832#issuecomment-29224325
+          cluster.workers[id].process.kill();
+        }
+
+        cleanup(function() {
+          process.exit();
+        });
+      });
+
+      for (var i = 0; i < clusterSize; i++) {
+        cluster.fork();
+      }
+    });
+
+  } else {
+    process.once('SIGTERM', function () {
+      setTimeout(process.exit, 1000);
+    });
+
+    queue.process(jobType, function (job, done) {
+      var n = job.data.n;
+
+      console.log('Process ' + process.pid + ' is processing job: ' + n);
+
+      client.get('prev', function (err, prev) {
+        if (n && (n - Number(prev) !== 1)) {
+          console.error('FAIL');
+          done();
+          process.exit(1);
+        }
+
+        setTimeout(function () {
+          client.set('prev', n, done);
+          if (n === 9) {
+            console.log('Success!');
+            process.exit();
+          }
+        }, 1000);
+      });
+    });
+  }
+
+  function cleanup (cb) {
+    kue.Job.range(0, -1, 'asc', function (err, jobs) {
+      for (var i = 0; i < jobs.length; i++) {
+        if (jobs[i].type === jobType) {
+          jobs[i].remove();
+        }
+      }
+      cb();
+    });
+  }
+})();


### PR DESCRIPTION
This PR is the first draft of what a full queue locking PR might be. It does the following:

1. Adds a lock of with ttl 10 seconds before processing each job
2. Removes the lock when the job is done
3. If the lock fails, it calls `process.nextTick` and then tries again.

Known limitations that need to be address;

1. Most users of kue want concurrency greater than 1. This PR assumes everyone wants concurrency = 1. This needs to be configurable.
2. The lock ttl needs to be configurable. Currently it is hard coded for 10 seconds
3. The queue-lock key should be unique to the job type, and probably use the `kue` prefix, which defaults to `q:`. So, something like `prefix:type:lock`.

Testing

The redis_lock script in the test directory is what I've come up with so far as a way to test this. It uses node's cluster module to create multiple processes that try to pull jobs off the queue. 

Run it like so `export SIZE=2 && node test/redis_lock.js`, changing `SIZE` from 1 to 2.

When the script is run WITHOUT the changes in lib/queue/worker.js, it should succeed with SIZE=1, but fail with SIZE=2. 

When the script is run WITH the changes in lib/queue/worker.js, it should succeed no matter what SIZE is. 